### PR TITLE
update frustum_intersect_aabb intersection semantics

### DIFF
--- a/math3dfunc.cpp
+++ b/math3dfunc.cpp
@@ -1168,7 +1168,7 @@ math3d_frustum_planes(struct math_context *M, math_t m, int homogeneous_depth) {
 int
 math3d_frustum_intersect_aabb(struct math_context *M, math_t planes, math_t aabb) {
 	int ii;
-
+	int r = 1;
 	check_type(M, aabb, MATH_TYPE_VEC4);
 
 	const glm::vec3 &min =  VEC3(M, math_index(M, aabb, 0));
@@ -1176,15 +1176,17 @@ math3d_frustum_intersect_aabb(struct math_context *M, math_t planes, math_t aabb
 
 	for (ii = 0; ii < 6; ++ii){
 		const auto &p = VEC(M, math_index(M, planes, ii));
-		const int r = plane_intersect(p, min, max);
-		// intersect or outside frustum
-		if (r <= 0){
+		int t = plane_intersect(p, min, max);
+		r = t < r ? t : r;
+		// r = -1, aabb outside one plane, means outside frustum
+		if (r < 0){
 			return r;
 		}
 	}
 
-	// aabb in front of all planes, mean inside frustum
-	return 1;
+	// r = 1, aabb in front of all planes, mean inside frustum
+	// r = 0, aabb in front of part planes or aabb intersect with part planes, mean intersect frustum
+	return r;
 }
 
 // point: [


### PR DESCRIPTION
The origin **frustum_intersect_aabb** use for the intersection test of camera frustum with aabb:
return -1 means aabb outside of one or more planes of frustum, outside frustum.
return 1 means aabb inside of all planes of frustum, inside frustum.
return 0 should have meant aabb intersect frusum, but **plane_intersect** merely means aabb intersect one plane.

In order to express the correct sematics of aabb intersect with frustum, aabb should be tested to each planes and ensure all intersection return value bigger than -1.