### PR TITLE
update projective matrix with infinite far plane

### DIFF
--- a/math3dfunc.h
+++ b/math3dfunc.h
@@ -67,5 +67,7 @@ int math3d_frustum_intersect_aabb(struct math_context *, math_t planes, math_t a
 math_t math3d_frustum_points(struct math_context *, math_t m, int homogeneous_depth);	// return vec4[8]
 void math3d_frustum_calc_near_far(struct math_context *, math_t planes, float result[2]); // return { near, far }
 float math3d_point2plane(struct math_context *, math_t pt, math_t plane);
-
+math_t math3d_perspectiveLH_INFF(struct math_context *M, float fovy, float aspect, float zNear, float zFar, int inv_z);
+math_t math3d_orthoLH_INFF(struct math_context *M, float left, float right, float bottom, float top, float near, float far, int inv_z);
+math_t math3d_frustumLH_INFF(struct math_context *M, float left, float right, float bottom, float top, float near, float far, int inv_z);
 #endif

--- a/test.lua
+++ b/test.lua
@@ -541,3 +541,36 @@ do
 
 	print(math3d.tostring(v))
 end
+
+-- PROJECTIVE MATRIX WITH INFINITE FAR PLANE TEST
+
+local function compare_perspective_camera(inv_z, n, f)
+    local p = math3d.projmat({n=n, f=f, fov=60, aspect=4/3}, inv_z)
+    local infp = math3d.projmat({n=n, f=f, fov=60, aspect=4/3}, inv_z, true)
+    local updir = math3d.vector(0, 1, 0)
+    local eyepos = math3d.vector(0, 0, 0)
+    local direction = math3d.normalize(math3d.vector(0, 0, 1))
+    local v = math3d.lookto(eyepos, direction, updir)
+    local vp = math3d.mul(p, v)
+    local vinfp = math3d.mul(infp, v)
+
+    local zz_n, ww_n = math3d.index(math3d.transform(vp, math3d.vector(0, 0, n), 1), 3, 4)
+    local zzinf_n, wwinf_n = math3d.index(math3d.transform(vinfp, math3d.vector(0, 0, n), 1), 3, 4)
+
+    local zz_m, ww_m = math3d.index(math3d.transform(vp, math3d.vector(0, 0, (n+f)*0.5), 1), 3, 4)
+    local zzinf_m, wwinf_m = math3d.index(math3d.transform(vinfp, math3d.vector(0, 0, (n+f)*0.5), 1), 3, 4)
+
+    local zz_f, ww_f = math3d.index(math3d.transform(vp, math3d.vector(0, 0, f), 1), 3, 4)
+    local zzinf_f, wwinf_f = math3d.index(math3d.transform(vinfp, math3d.vector(0, 0, f), 1), 3, 4)
+    
+    local ndf_n, ndf_n_inf = zz_n / ww_n, zzinf_n / wwinf_n
+    local ndf_m, ndf_m_inf = zz_m / ww_m, zzinf_m / wwinf_m
+    local ndf_f, ndf_f_inf = zz_f / ww_f, zzinf_f / wwinf_f    
+    return ndf_n, ndf_n_inf, ndf_m, ndf_m_inf, ndf_f, ndf_f_inf
+end
+
+
+local ndf_n, ndf_n_inf, ndf_m, ndf_m_inf, ndf_f, ndf_f_inf = compare_perspective_camera(false, 0.1, 10000)
+ndf_n, ndf_n_inf, ndf_m, ndf_m_inf, ndf_f, ndf_f_inf= compare_perspective_camera(true, 0.1, 20000)
+ndf_n, ndf_n_inf, ndf_m, ndf_m_inf, ndf_f, ndf_f_inf = compare_perspective_camera(false, 0.01, 1000)
+ndf_n, ndf_n_inf, ndf_m, ndf_m_inf, ndf_f, ndf_f_inf = compare_perspective_camera(true, 0.01, 2000)


### PR DESCRIPTION
This PR add the interface of ortho/perspective project matrix with infinite far plane create.

Infinite far plane of perspective matrix with left handiness (z in [0, w])：

- math3d_frustumLH_INFF
- math3d_perspectiveLH_INFF

Infinite far plane of orthotropic matrix with left handiness (z in [0, w])：
math3d_orthoLH_INFF