### PR TITLE
update glm to fix create quaternion from two vector

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -133,6 +133,17 @@ do
 	print(ref3)
 
 	print(math3d.tostring(math3d.constant "quat", math3d.constant "quat"))	-- Identity quat
+
+	--use two vector to create quaternion
+	local v1 = math3d.vector(1.0, 0.0, 0.0, 0.0)
+	local v2 = math3d.vector(1.0, 0.0, 0.0, 0.0)
+	local q1 = math3d.quaternion(v1, v2)
+	assert(math3d.isequal(q1, math3d.quaternion(0.0, 0.0, 0.0, 1.0)))
+
+	--rotate z-axis by 90 degree
+	local v3 = math3d.vector(0.0, 1.0, 0.0, 0.0)
+	local q2 = math3d.quaternion(v1, v3)
+	assert(math3d.isequal(q2, math3d.quaternion{r=math.rad(90), axis=math3d.vector(0.0, 0.0, 1.0)}))
 end
 
 print "===FUNC==="


### PR DESCRIPTION
通过两个vector构建四元数时会有bug。看起来是glm在支持四元数从xyzw和wxyz构建时没有改全导致的bug。
更新到最新的glm后，这个问题已经修复了。我在test.lua里面也加入相应的测试代码。

当前版本：
https://github.com/g-truc/glm/blob/cc98465e3508535ba8c7f6208df934c156a018dc/glm/detail/type_quat.inl#L204

glm最新版本：
https://github.com/g-truc/glm/blob/master/glm/detail/type_quat.inl#L203